### PR TITLE
Add initial Go anti-spam project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Simple multi-stage build for development
+FROM golang:1.23 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o antispam ./cmd/antispam
+
+FROM debian:stable-slim
+WORKDIR /app
+COPY --from=builder /app/antispam /usr/local/bin/antispam
+COPY config/config.yaml /etc/antispam/config.yaml
+EXPOSE 8080
+CMD ["/usr/local/bin/antispam"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # antispam
+
+Estructura inicial para una aplicación antispam en Go que interactúa con Postfix a través del protocolo Milter. El proyecto se divide en varios paquetes:
+
+- **`internal/milter`**: servidor que implementa Milter usando `go-milter` y delega en el módulo antispam.
+- **`internal/antispam`**: lógica básica de detección por heurísticas y listas blancas/negras en memoria.
+- **`internal/api`**: API REST basada en Gin para gestionar las listas.
+- **`config`**: estructuras y ejemplo de configuración YAML.
+- **`cmd/antispam`**: punto de entrada de la aplicación.
+
+Se incluye además un `Dockerfile` para compilar y ejecutar la aplicación fácilmente.

--- a/cmd/antispam/main.go
+++ b/cmd/antispam/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/example/antispam/config"
+	am "github.com/example/antispam/internal/antispam"
+	"github.com/example/antispam/internal/api"
+	"github.com/example/antispam/internal/milter"
+)
+
+func main() {
+	cfg, err := config.Load("config/config.yaml")
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	scorer := am.NewScorer()
+
+	apiSrv := api.NewServer(cfg.API.Addr, scorer)
+	milterSrv := milter.NewServer(cfg.Milter.Addr, scorer)
+
+	// Run API in separate goroutine
+	go func() {
+		if err := apiSrv.Run(); err != nil {
+			log.Fatalf("api server error: %v", err)
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := milterSrv.Serve(ctx); err != nil {
+		log.Fatalf("milter error: %v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
+)
+
+// Config represents application configuration loaded from YAML.
+type Config struct {
+	API struct {
+		Addr string `yaml:"addr"`
+	} `yaml:"api"`
+	Milter struct {
+		Addr string `yaml:"addr"`
+	} `yaml:"milter"`
+	Logging struct {
+		Level string `yaml:"level"`
+	} `yaml:"logging"`
+}
+
+// Load reads the given YAML file into a Config.
+func Load(path string) (*Config, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,6 @@
+api:
+  addr: ":8080"
+milter:
+  addr: "unix:///var/spool/postfix/milter.sock"
+logging:
+  level: "info"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/antispam
+
+go 1.23.8

--- a/internal/antispam/heuristic.go
+++ b/internal/antispam/heuristic.go
@@ -1,0 +1,59 @@
+package antispam
+
+import "strings"
+
+// Message represents minimal information about an email used for scoring.
+type Message struct {
+	From    string
+	Subject string
+	Body    string
+}
+
+// Scorer applies heuristic scoring to detect spam.
+type Scorer struct {
+	Keywords  map[string]int
+	Threshold int
+	Whitelist map[string]struct{}
+	Blacklist map[string]struct{}
+}
+
+// NewScorer creates a new Scorer with default settings.
+func NewScorer() *Scorer {
+	return &Scorer{
+		Keywords:  map[string]int{"buy now": 5, "free": 3},
+		Threshold: 5,
+		Whitelist: make(map[string]struct{}),
+		Blacklist: make(map[string]struct{}),
+	}
+}
+
+// AddToWhitelist adds an address to the whitelist.
+func (s *Scorer) AddToWhitelist(addr string) { s.Whitelist[addr] = struct{}{} }
+
+// AddToBlacklist adds an address to the blacklist.
+func (s *Scorer) AddToBlacklist(addr string) { s.Blacklist[addr] = struct{}{} }
+
+// Score calculates a spam score for the message.
+func (s *Scorer) Score(msg *Message) int {
+	if _, ok := s.Whitelist[msg.From]; ok {
+		return 0
+	}
+	if _, ok := s.Blacklist[msg.From]; ok {
+		return s.Threshold
+	}
+	score := 0
+	text := msg.Subject + " " + msg.Body
+	for kw, val := range s.Keywords {
+		if containsIgnoreCase(text, kw) {
+			score += val
+		}
+	}
+	return score
+}
+
+// IsSpam returns true if the score is above the threshold.
+func (s *Scorer) IsSpam(msg *Message) bool { return s.Score(msg) >= s.Threshold }
+
+func containsIgnoreCase(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"net/http"
+
+	antispam "github.com/example/antispam/internal/antispam"
+	"github.com/gin-gonic/gin"
+)
+
+// Server exposes a REST API to manage antispam configuration.
+type Server struct {
+	addr   string
+	scorer *antispam.Scorer
+}
+
+// NewServer creates a new API server on the given address.
+func NewServer(addr string, scorer *antispam.Scorer) *Server {
+	return &Server{addr: addr, scorer: scorer}
+}
+
+// Run starts the HTTP server.
+func (s *Server) Run() error {
+	r := gin.Default()
+
+	r.GET("/whitelist", func(c *gin.Context) {
+		c.JSON(http.StatusOK, s.scorerWhitelist())
+	})
+	r.POST("/whitelist/:addr", func(c *gin.Context) {
+		addr := c.Param("addr")
+		s.scorer.AddToWhitelist(addr)
+		c.Status(http.StatusCreated)
+	})
+
+	r.GET("/blacklist", func(c *gin.Context) {
+		c.JSON(http.StatusOK, s.scorerBlacklist())
+	})
+	r.POST("/blacklist/:addr", func(c *gin.Context) {
+		addr := c.Param("addr")
+		s.scorer.AddToBlacklist(addr)
+		c.Status(http.StatusCreated)
+	})
+
+	return r.Run(s.addr)
+}
+
+func (s *Server) scorerWhitelist() []string {
+	res := make([]string, 0, len(s.scorer.Whitelist))
+	for addr := range s.scorer.Whitelist {
+		res = append(res, addr)
+	}
+	return res
+}
+
+func (s *Server) scorerBlacklist() []string {
+	res := make([]string, 0, len(s.scorer.Blacklist))
+	for addr := range s.scorer.Blacklist {
+		res = append(res, addr)
+	}
+	return res
+}

--- a/internal/milter/milter.go
+++ b/internal/milter/milter.go
@@ -1,0 +1,63 @@
+package milter
+
+import (
+	"context"
+	"log"
+
+	milter "github.com/emersion/go-milter"
+	antimod "github.com/example/antispam/internal/antispam"
+)
+
+// Server wraps the go-milter library and delegates spam detection to Scorer.
+type Server struct {
+	addr   string
+	scorer *antimod.Scorer
+}
+
+// NewServer creates a new Milter server.
+func NewServer(addr string, scorer *antimod.Scorer) *Server {
+	return &Server{addr: addr, scorer: scorer}
+}
+
+// Serve starts listening for connections from Postfix.
+func (s *Server) Serve(ctx context.Context) error {
+	srv := milter.Server{
+		Addr: s.addr,
+		// Each connection will create a session that implements the Handler interface.
+		// Using inline struct for brevity.
+		Factory: func() (milter.Milter, error) {
+			return &session{scorer: s.scorer}, nil
+		},
+	}
+	return srv.ListenAndServe(ctx)
+}
+
+type session struct {
+	milter.Session
+	scorer *antimod.Scorer
+}
+
+// Connect is called at the start of a new SMTP session.
+func (s *session) Connect(ctx context.Context, c *milter.Connect) error {
+	log.Printf("connect from %s", c.Host)
+	return nil
+}
+
+// Headers returns continue to let Postfix send body.
+func (s *session) Headers(ctx context.Context, h *milter.Headers) error {
+	return nil
+}
+
+// Body is called with the full message body.
+func (s *session) Body(ctx context.Context, b *milter.Body) error {
+	msg := &antimod.Message{
+		From:    b.MailFrom,
+		Subject: b.Header.Get("Subject"),
+		Body:    string(b.Bytes()),
+	}
+	if s.scorer.IsSpam(msg) {
+		// Reject spam messages.
+		return milter.NewResponse(550, 5, 7, "Message rejected as spam")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- structure a Milter-based anti-spam app
- implement basic heuristic spam scorer
- expose whitelist/blacklist management via Gin API
- provide YAML configuration and Dockerfile

## Testing
- `gofmt -w cmd/antispam/main.go internal/api/server.go internal/antispam/heuristic.go internal/milter/milter.go config/config.go`
- `go build ./cmd/antispam` *(fails: no module for github.com/emersion/go-milter, github.com/gin-gonic/gin, gopkg.in/yaml.v3)*
- `go vet ./...` *(fails: no module for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851945789448320a5c16966b9da6997