### PR TITLE
Replace go-milter with minimal stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Estructura inicial para una aplicación antispam en Go que interactúa con Postfix a través del protocolo Milter. El proyecto se divide en varios paquetes:
 
-- **`internal/milter`**: servidor que implementa Milter usando `go-milter` y delega en el módulo antispam. El socket puede ser TCP o Unix según la configuración.
+- **`internal/milter`**: servidor que implementa de forma simplificada el protocolo Milter y delega en el módulo antispam. El socket puede ser TCP o Unix según la configuración.
 - **`internal/antispam`**: lógica básica de detección por heurísticas y listas blancas/negras en memoria.
 - **`internal/api`**: API REST basada en Gin para gestionar las listas.
 - **`config`**: estructuras y ejemplo de configuración YAML (incluye red y dirección para el Milter).


### PR DESCRIPTION
## Summary
- remove dependency on `go-milter`
- implement a simple stubbed Milter server
- update README to reflect simplified implementation

## Testing
- `go vet ./...` *(fails: module dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68519e3df74c8320aa8c4e6a61771e8c