### PR TITLE
Fix config path and missing file handling

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,9 +24,13 @@ func LoadConfig() (*Config, error) {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(".")
+	viper.AddConfigPath("cmd/antispam")
 
 	if err := viper.ReadInConfig(); err != nil {
-		return nil, fmt.Errorf("error reading config file: %s", err)
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			return nil, fmt.Errorf("config file not found: %w", err)
+		}
+		return nil, fmt.Errorf("error reading config file: %w", err)
 	}
 
 	// Load environment variables


### PR DESCRIPTION
## Summary
- load config files from `cmd/antispam`
- provide clearer error when the config file is missing

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851ccfdbbd483208bb3c6dda87b2318