### PR TITLE
Fix go version in mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mail-cci/antispam
 
-go 1.23.8
+go 1.22
 
 require (
 	github.com/emersion/go-milter v0.4.1


### PR DESCRIPTION
## Summary
- update Go to a released version in go.mod

## Testing
- `go mod tidy -e` *(fails: `Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_6851ce139dd48320a1f3fa7927af3877