### PR TITLE
Implement full email parsing in milter

### DIFF
--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -1,0 +1,58 @@
+package milt
+
+import (
+	"net/textproto"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-milter"
+	"go.uber.org/zap"
+)
+
+func TestEmailParsing(t *testing.T) {
+	logger := zap.NewNop()
+	e := MailProcessor(logger)
+	defer e.Close()
+
+	hdr := textproto.MIMEHeader{}
+	hdr.Add("From", "a@b")
+	hdr.Add("To", "c@d")
+	hdr.Add("Subject", "Test")
+	hdr.Add("Content-Type", "multipart/mixed; boundary=\"b\"")
+
+	if _, err := e.Headers(hdr, nil); err != nil {
+		t.Fatalf("Headers returned error: %v", err)
+	}
+
+	body := strings.Join([]string{
+		"--b",
+		"Content-Type: text/plain",
+		"",
+		"Hello",
+		"--b",
+		"Content-Type: text/plain",
+		"Content-Disposition: attachment; filename=\"file.txt\"",
+		"",
+		"content",
+		"--b--",
+		"",
+	}, "\r\n")
+
+	if _, err := e.BodyChunk([]byte(body), nil); err != nil {
+		t.Fatalf("BodyChunk error: %v", err)
+	}
+
+	if resp, err := e.Body(nil); err != nil || resp != milter.RespAccept {
+		t.Fatalf("Body returned resp=%v err=%v", resp, err)
+	}
+
+	if e.rawBody.String() != "Hello\r\n" {
+		t.Errorf("unexpected body: %q", e.rawBody.String())
+	}
+	if len(e.attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(e.attachments))
+	}
+	if e.attachments[0].Filename != "file.txt" {
+		t.Errorf("unexpected attachment name: %s", e.attachments[0].Filename)
+	}
+}


### PR DESCRIPTION
## Summary
- extend milter Email struct with headers and attachments
- parse body and attachments using `go-message`
- add unit test for parsing

## Testing
- `go test ./...` *(fails: fetching modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851d663f5048320931c923a4da32c99