### PR TITLE
Fix BodyChunk logging panic and test short chunk

### DIFF
--- a/internal/milter/milter.go
+++ b/internal/milter/milter.go
@@ -122,8 +122,12 @@ func (e *Email) Headers(h textproto.MIMEHeader, m *milter.Modifier) (milter.Resp
 }
 
 func (e *Email) BodyChunk(chunk []byte, m *milter.Modifier) (milter.Response, error) {
+	preview := chunk
+	if len(preview) > 10 {
+		preview = preview[:10]
+	}
 	e.logger.Debug("[cci-spam-inbound-prefilter] - BodyChunk: ",
-		zap.String("chunk", string(chunk[:10])),
+		zap.String("chunk", string(preview)),
 		zap.String("correlation_id", e.id),
 		zap.String("type", "body_chunk"))
 	e.rawBody.Write(chunk)

--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -56,3 +56,19 @@ func TestEmailParsing(t *testing.T) {
 		t.Errorf("unexpected attachment name: %s", e.attachments[0].Filename)
 	}
 }
+
+func TestBodyChunkShort(t *testing.T) {
+	logger := zap.NewNop()
+	e := MailProcessor(logger)
+	defer e.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("BodyChunk panicked: %v", r)
+		}
+	}()
+
+	if resp, err := e.BodyChunk([]byte("short"), nil); err != nil || resp != milter.RespContinue {
+		t.Fatalf("BodyChunk returned resp=%v err=%v", resp, err)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid slice bounds panic in `BodyChunk` by truncating safely
- add test ensuring short chunks don't panic

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851e3b87ee88320a0d8b75c1ac71050