### PR TITLE
Add email saving to testdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ start the application:
 The program will start the milter and HTTP servers using the ports defined
 in the configuration file.
 
+All emails received by the milter are also stored as `.eml` files under the
+`testdata` directory for inspection.
+
 ## Testing
 
 Unit tests can be executed with:

--- a/internal/milter/charset.go
+++ b/internal/milter/charset.go
@@ -1,0 +1,10 @@
+package milt
+
+import (
+	"github.com/emersion/go-message"
+	"golang.org/x/net/html/charset"
+)
+
+func init() {
+	message.CharsetReader = charset.NewReaderLabel
+}

--- a/internal/milter/milter.go
+++ b/internal/milter/milter.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/emersion/go-message/mail"
 	"github.com/emersion/go-milter"
@@ -148,6 +150,13 @@ func (e *Email) Body(m *milter.Modifier) (milter.Response, error) {
 	}
 	raw.WriteString("\r\n")
 	raw.Write(e.rawBody.Bytes())
+
+	// Save raw email for testing/debugging purposes
+	fileName := e.id + ".eml"
+	filePath := filepath.Join("testdata", fileName)
+	if err := os.WriteFile(filePath, raw.Bytes(), 0644); err != nil {
+		e.logger.Error("failed to write email file", zap.Error(err))
+	}
 
 	mr, err := mail.CreateReader(&raw)
 	if err != nil {

--- a/internal/milter/milter.go
+++ b/internal/milter/milter.go
@@ -154,6 +154,9 @@ func (e *Email) Body(m *milter.Modifier) (milter.Response, error) {
 	// Save raw email for testing/debugging purposes
 	fileName := e.id + ".eml"
 	filePath := filepath.Join("testdata", fileName)
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		e.logger.Error("failed to create testdata directory", zap.Error(err))
+	}
 	if err := os.WriteFile(filePath, raw.Bytes(), 0644); err != nil {
 		e.logger.Error("failed to write email file", zap.Error(err))
 	}

--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -54,7 +54,7 @@ func TestEmailParsing(t *testing.T) {
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected email file %s not found: %v", path, err)
 	}
-	os.Remove(path)
+	t.Cleanup(func() { os.Remove(path) })
 
 	if e.rawBody.String() != "Hello" {
 		t.Errorf("unexpected body: %q", e.rawBody.String())

--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -2,6 +2,8 @@ package milt
 
 import (
 	"net/textproto"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -45,6 +47,14 @@ func TestEmailParsing(t *testing.T) {
 	if resp, err := e.Body(nil); err != nil || resp != milter.RespAccept {
 		t.Fatalf("Body returned resp=%v err=%v", resp, err)
 	}
+
+	// Verify email file was created
+	fileName := e.id + ".eml"
+	path := filepath.Join("testdata", fileName)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected email file %s not found: %v", path, err)
+	}
+	os.Remove(path)
 
 	if e.rawBody.String() != "Hello" {
 		t.Errorf("unexpected body: %q", e.rawBody.String())


### PR DESCRIPTION
## Summary
- store incoming emails in `testdata` as `.eml`
- test new email-saving functionality
- document saved emails in README

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851e6b1301883208fe4b5af5d5afae6