### PR TITLE
Implement MySQL storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ start the application:
 The program will start the milter and HTTP servers using the ports defined
 in the configuration file.
 
+## Database
+
+The application uses MySQL to persist processed emails. Connection settings are
+configured in `cmd/antispam/config.yaml` under the `database` section. A helper
+initialization in the code will automatically create the required tables:
+
+- `emails` – main metadata
+- `email_headers` – individual header fields
+- `email_attachments` – attachment contents
+- `spam_scores` – analysis results
+- `quarantine` – quarantined emails
+
+Ensure a MySQL instance is available and the configured user has privileges to
+create tables.
+
 ## Testing
 
 Unit tests can be executed with:

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,10 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/satori/go.uuid v1.2.0
-	github.com/spf13/viper v1.20.1
-	go.uber.org/zap v1.27.0
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+       github.com/spf13/viper v1.20.1
+       go.uber.org/zap v1.27.0
+       gopkg.in/natefinch/lumberjack.v2 v2.2.1
+       github.com/go-sql-driver/mysql v1.7.1
 )
 
 require (

--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestEmailParsing(t *testing.T) {
 	logger := zap.NewNop()
-	e := MailProcessor(logger)
+	e := MailProcessor(logger, nil)
 	defer e.Close()
 
 	hdr := textproto.MIMEHeader{}
@@ -59,7 +59,7 @@ func TestEmailParsing(t *testing.T) {
 
 func TestBodyChunkShort(t *testing.T) {
 	logger := zap.NewNop()
-	e := MailProcessor(logger)
+	e := MailProcessor(logger, nil)
 	defer e.Close()
 
 	defer func() {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,122 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type Storage struct {
+	DB *sql.DB
+}
+
+func New(dsn string, maxConns int) (*Storage, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(maxConns)
+	db.SetMaxIdleConns(maxConns)
+	return &Storage{DB: db}, nil
+}
+
+func (s *Storage) Close() error {
+	return s.DB.Close()
+}
+
+func (s *Storage) InitSchema(ctx context.Context) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS emails (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            correlation_id VARCHAR(36) NOT NULL,
+            from_address VARCHAR(255),
+            helo VARCHAR(255),
+            host VARCHAR(255),
+            port VARCHAR(10),
+            addr VARCHAR(45),
+            body TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )`,
+		`CREATE TABLE IF NOT EXISTS email_headers (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            email_id BIGINT,
+            name VARCHAR(255),
+            value TEXT,
+            FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+        )`,
+		`CREATE TABLE IF NOT EXISTS email_attachments (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            email_id BIGINT,
+            filename TEXT,
+            content_type VARCHAR(255),
+            data LONGBLOB,
+            FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+        )`,
+		`CREATE TABLE IF NOT EXISTS spam_scores (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            email_id BIGINT,
+            score FLOAT,
+            details TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+        )`,
+		`CREATE TABLE IF NOT EXISTS quarantine (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            email_id BIGINT,
+            reason TEXT,
+            quarantined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            released_at TIMESTAMP NULL,
+            FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+        )`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.DB.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Storage) SaveEmail(ctx context.Context, e *milt.Email) error {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO emails (correlation_id, from_address, helo, host, port, addr, body)
+         VALUES (?,?,?,?,?,?,?)`,
+		e.ID(), e.From(), e.Helo(), e.Client()["host"], e.Client()["port"], e.Client()["addr"], e.Body(),
+	)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	emailID, err := res.LastInsertId()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	for name, values := range e.Headers() {
+		for _, v := range values {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO email_headers (email_id, name, value) VALUES (?,?,?)`,
+				emailID, name, v,
+			); err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+	}
+	for _, att := range e.Attachments() {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO email_attachments (email_id, filename, content_type, data)
+             VALUES (?,?,?,?)`,
+			emailID, att.Filename, att.ContentType, att.Data,
+		); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS emails (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    correlation_id VARCHAR(36) NOT NULL,
+    from_address VARCHAR(255),
+    helo VARCHAR(255),
+    host VARCHAR(255),
+    port VARCHAR(10),
+    addr VARCHAR(45),
+    body TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS email_headers (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email_id BIGINT,
+    name VARCHAR(255),
+    value TEXT,
+    FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS email_attachments (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email_id BIGINT,
+    filename TEXT,
+    content_type VARCHAR(255),
+    data LONGBLOB,
+    FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS spam_scores (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email_id BIGINT,
+    score FLOAT,
+    details TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS quarantine (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email_id BIGINT,
+    reason TEXT,
+    quarantined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    released_at TIMESTAMP NULL,
+    FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+);
+


### PR DESCRIPTION
## Summary
- add MySQL storage package and schema definitions
- wire storage into milter
- document database usage
- include SQL schema for creating tables

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851ed03dac083208cd6da74df5876d1