### PR TITLE
Implement MySQL storage layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ toolchain go1.23.8
 require (
 	github.com/emersion/go-milter v0.4.1
 	github.com/gin-contrib/cors v1.7.5
-	github.com/gin-gonic/gin v1.10.1
-	github.com/prometheus/client_golang v1.22.0
-	github.com/satori/go.uuid v1.2.0
-	github.com/spf13/viper v1.20.1
-	go.uber.org/zap v1.27.0
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+        github.com/gin-gonic/gin v1.10.1
+        github.com/prometheus/client_golang v1.22.0
+       github.com/go-sql-driver/mysql v1.7.1
+        github.com/satori/go.uuid v1.2.0
+        github.com/spf13/viper v1.20.1
+        go.uber.org/zap v1.27.0
+        gopkg.in/natefinch/lumberjack.v2 v2.2.1
+       github.com/DATA-DOG/go-sqlmock v1.5.0
 )
 
 require (

--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestEmailParsing(t *testing.T) {
 	logger := zap.NewNop()
-	e := MailProcessor(logger)
+	e := MailProcessor(logger, nil)
 	defer e.Close()
 
 	hdr := textproto.MIMEHeader{}
@@ -59,7 +59,7 @@ func TestEmailParsing(t *testing.T) {
 
 func TestBodyChunkShort(t *testing.T) {
 	logger := zap.NewNop()
-	e := MailProcessor(logger)
+	e := MailProcessor(logger, nil)
 	defer e.Close()
 
 	defer func() {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,89 @@
+package storage
+
+import (
+	"database/sql"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	milt "github.com/mail-cci/antispam/internal/milter"
+)
+
+// New opens a MySQL connection using the provided URL and limits the number of
+// open connections.
+func New(dbURL string, maxConns int) (*sql.DB, error) {
+	db, err := sql.Open("mysql", dbURL)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(maxConns)
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// Store wraps a sql.DB to implement the milter.Store interface.
+type Store struct{ DB *sql.DB }
+
+// NewStore creates a Store using the provided DB.
+func NewStore(db *sql.DB) *Store { return &Store{DB: db} }
+
+// SaveEmail persists the email, its headers and attachments. It returns the
+// generated email ID.
+func (s *Store) SaveEmail(e *milt.Email) (int64, error) {
+	tx, err := s.DB.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		} else {
+			err = tx.Commit()
+		}
+	}()
+
+	res, err := tx.Exec(`INSERT INTO emails (correlation_id, envelope_from, client_ip, helo, received_at, body)
+        VALUES (?,?,?,?,?,?)`,
+		e.ID(), e.From(), e.ClientAddr(), e.Helo(), time.Now(), e.Body())
+	if err != nil {
+		return 0, err
+	}
+	emailID, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	for name, vals := range e.Headers() {
+		for _, v := range vals {
+			if _, err = tx.Exec(`INSERT INTO email_headers (email_id, name, value) VALUES (?,?,?)`,
+				emailID, name, v); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	for _, att := range e.Attachments() {
+		if _, err = tx.Exec(`INSERT INTO email_attachments (email_id, filename, content_type, content) VALUES (?,?,?,?)`,
+			emailID, att.Filename, att.ContentType, att.Data); err != nil {
+			return 0, err
+		}
+	}
+
+	return emailID, nil
+}
+
+// SaveSpamScore stores the results of a spam engine for a message.
+func (s *Store) SaveSpamScore(emailID int64, engine string, score, threshold float64, isSpam bool) error {
+	_, err := s.DB.Exec(`INSERT INTO spam_scores (email_id, engine, score, threshold, is_spam) VALUES (?,?,?,?,?)`,
+		emailID, engine, score, threshold, isSpam)
+	return err
+}
+
+// QuarantineEmail records that an email has been quarantined for the given reason.
+func (s *Store) QuarantineEmail(emailID int64, reason string) error {
+	_, err := s.DB.Exec(`INSERT INTO quarantine (email_id, reason, quarantined_at) VALUES (?,?,?)`,
+		emailID, reason, time.Now())
+	return err
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,0 +1,86 @@
+package storage
+
+import (
+	"net"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	milt "github.com/mail-cci/antispam/internal/milter"
+	"go.uber.org/zap"
+)
+
+func TestSaveEmail(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	e := milt.MailProcessor(zap.NewNop(), nil)
+	e.Connect("host", "tcp", 25, net.ParseIP("1.2.3.4"), nil)
+	e.Helo("mx.example", nil)
+	e.MailFrom("alice@example.com", nil)
+	e.Header("Subject", "Test", nil)
+	e.BodyChunk([]byte("body"), nil)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO emails").
+		WithArgs(e.ID(), e.From(), e.ClientAddr(), e.Helo(), sqlmock.AnyArg(), e.Body()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO email_headers").
+		WithArgs(1, "Subject", "Test").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	store := NewStore(db)
+	id, err := store.SaveEmail(e)
+	if err != nil {
+		t.Fatalf("SaveEmail returned error: %v", err)
+	}
+	if id != 1 {
+		t.Errorf("expected id 1 got %d", id)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestSaveSpamScore(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT INTO spam_scores").
+		WithArgs(1, "engine", 5.0, 4.0, true).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	store := NewStore(db)
+	if err := store.SaveSpamScore(1, "engine", 5.0, 4.0, true); err != nil {
+		t.Fatalf("SaveSpamScore error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestQuarantineEmail(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT INTO quarantine").
+		WithArgs(1, "reason", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	store := NewStore(db)
+	if err := store.QuarantineEmail(1, "reason"); err != nil {
+		t.Fatalf("QuarantineEmail error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS emails (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    correlation_id VARCHAR(255),
+    envelope_from VARCHAR(255),
+    client_ip VARCHAR(45),
+    helo VARCHAR(255),
+    received_at DATETIME,
+    body MEDIUMTEXT
+);
+
+CREATE TABLE IF NOT EXISTS email_headers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email_id INT,
+    name VARCHAR(255),
+    value TEXT,
+    FOREIGN KEY (email_id) REFERENCES emails(id)
+);
+
+CREATE TABLE IF NOT EXISTS email_attachments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email_id INT,
+    filename VARCHAR(255),
+    content_type VARCHAR(255),
+    content LONGBLOB,
+    FOREIGN KEY (email_id) REFERENCES emails(id)
+);
+
+CREATE TABLE IF NOT EXISTS spam_scores (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email_id INT,
+    engine VARCHAR(255),
+    score DOUBLE,
+    threshold DOUBLE,
+    is_spam BOOLEAN,
+    FOREIGN KEY (email_id) REFERENCES emails(id)
+);
+
+CREATE TABLE IF NOT EXISTS quarantine (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email_id INT,
+    reason TEXT,
+    quarantined_at DATETIME,
+    FOREIGN KEY (email_id) REFERENCES emails(id)
+);


### PR DESCRIPTION
## Summary
- add go-sql-driver/mysql and sqlmock dependencies
- implement storage package with MySQL helpers
- load DB in main and pass store to milter
- persist incoming messages from milter
- provide DB schema SQL and unit tests

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853130c3238832083f32e126a083a5b