### PR TITLE
Add email analysis types

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,31 @@
+package types
+
+// SPFResult holds information about SPF check results.
+type SPFResult struct {
+	Result      string
+	Domain      string
+	Explanation string
+	Score       float64
+}
+
+// DKIMResult represents DKIM verification outcomes.
+type DKIMResult struct {
+	Valid    bool
+	Domain   string
+	Selector string
+	Score    float64
+}
+
+// AuthResult aggregates SPF and DKIM results.
+type AuthResult struct {
+	SPF  SPFResult
+	DKIM DKIMResult
+}
+
+// EmailAnalysis stores authentication and scoring information for an email.
+type EmailAnalysis struct {
+	MessageID  string
+	AuthResult AuthResult
+	TotalScore float64
+	Decision   string
+}


### PR DESCRIPTION
## Summary
- define SPFResult, DKIMResult, AuthResult and EmailAnalysis structs

## Testing
- `go test ./...` *(fails: unable to download modules due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685327edde908320bfb0a661d49d8ecb