### PR TITLE
Extend config with auth and scoring

### DIFF
--- a/cmd/antispam/config.yaml
+++ b/cmd/antispam/config.yaml
@@ -26,6 +26,19 @@ redis:
 http:
   timeout: "10s"
 
+auth:
+  spf:
+    enabled: true
+    timeout: 3s
+    cache_ttl: 1h
+  dkim:
+    enabled: true
+    timeout: 5s
+
+scoring:
+  reject_threshold: 10.0
+  quarantine_threshold: 5.0
+
 metrics:
   enabled: true
   path: "/metrics"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,27 @@ import (
 	"github.com/spf13/viper"
 )
 
+type SPFConfig struct {
+	Enabled  bool
+	Timeout  time.Duration
+	CacheTTL time.Duration
+}
+
+type DKIMConfig struct {
+	Enabled bool
+	Timeout time.Duration
+}
+
+type ScoringConfig struct {
+	RejectThreshold     float64
+	QuarantineThreshold float64
+}
+
+type AuthConfig struct {
+	SPF  SPFConfig
+	DKIM DKIMConfig
+}
+
 type Config struct {
 	Env              string
 	LogLevel         string
@@ -18,6 +39,8 @@ type Config struct {
 	RedisURL         string
 	RedisTimeout     time.Duration
 	HTTPTimeout      time.Duration
+	Auth             AuthConfig
+	Scoring          ScoringConfig
 }
 
 func LoadConfig() (*Config, error) {
@@ -47,6 +70,21 @@ func LoadConfig() (*Config, error) {
 		RedisURL:         viper.GetString("redis.url"),
 		RedisTimeout:     viper.GetDuration("redis.timeout"),
 		HTTPTimeout:      viper.GetDuration("http.timeout"),
+		Auth: AuthConfig{
+			SPF: SPFConfig{
+				Enabled:  viper.GetBool("auth.spf.enabled"),
+				Timeout:  viper.GetDuration("auth.spf.timeout"),
+				CacheTTL: viper.GetDuration("auth.spf.cache_ttl"),
+			},
+			DKIM: DKIMConfig{
+				Enabled: viper.GetBool("auth.dkim.enabled"),
+				Timeout: viper.GetDuration("auth.dkim.timeout"),
+			},
+		},
+		Scoring: ScoringConfig{
+			RejectThreshold:     viper.GetFloat64("scoring.reject_threshold"),
+			QuarantineThreshold: viper.GetFloat64("scoring.quarantine_threshold"),
+		},
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Summary
- add SPF/DKIM/auth scoring structs to configuration
- parse the new config keys in `LoadConfig`
- update default config values

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685328a85b788320b6fbc4c4798aa620