### PR TITLE
Implement DKIM verification helper

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7
 github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
 github.com/emersion/go-milter v0.4.1 h1:gLs9QD0zEHF8omgEw8M+aGz6iwBNpWLAcwgSur0ra4M=
 github.com/emersion/go-milter v0.4.1/go.mod h1:erCQVl0mH4SX9jEvwe+wyndit0rQtmvMLH86V6NGtkI=
+github.com/emersion/go-msgauth v0.6.8 h1:kW/0E9E8Zx5CdKsERC/WnAvnXvX7q9wTHia1OA4944A=
 github.com/emersion/go-msgauth v0.6.8/go.mod h1:YDwuyTCUHu9xxmAeVj0eW4INnwB6NNZoPdLerpSxRrc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
@@ -186,3 +187,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -1,0 +1,69 @@
+package dkim
+
+import (
+	"bytes"
+	"context"
+	"net"
+
+	"github.com/emersion/go-msgauth/dkim"
+
+	"github.com/mail-cci/antispam/internal/config"
+	"github.com/mail-cci/antispam/internal/types"
+)
+
+var cfg *config.Config
+
+// Init stores the application config for DKIM verification.
+func Init(c *config.Config) {
+	cfg = c
+}
+
+func scoreFor(valid bool) float64 {
+	if valid {
+		return -1
+	}
+	return 3
+}
+
+// Verify checks all DKIM signatures in the provided raw email. It returns a
+// DKIMResult with Valid=true if at least one signature verifies correctly.
+func Verify(rawEmail []byte) (*types.DKIMResult, error) {
+	res := &types.DKIMResult{}
+
+	// Setup a context with timeout for DNS lookups if configured.
+	ctx := context.Background()
+	if cfg != nil && cfg.Auth.DKIM.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.Auth.DKIM.Timeout)
+		defer cancel()
+	}
+
+	// Use VerifyWithOptions so DNS queries respect the context timeout.
+	verifs, err := dkim.VerifyWithOptions(bytes.NewReader(rawEmail), &dkim.VerifyOptions{
+		LookupTXT: func(domain string) ([]string, error) {
+			return net.DefaultResolver.LookupTXT(ctx, domain)
+		},
+	})
+	if err != nil && len(verifs) == 0 {
+		return nil, err
+	}
+
+	if len(verifs) == 0 {
+		// No signatures present.
+		res.Valid = false
+		res.Score = 0
+		return res, nil
+	}
+
+	for _, v := range verifs {
+		if res.Domain == "" {
+			res.Domain = v.Domain
+		}
+		if v.Err == nil {
+			res.Valid = true
+		}
+	}
+
+	res.Score = scoreFor(res.Valid)
+	return res, nil
+}

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -1,0 +1,12 @@
+package dkim
+
+import "testing"
+import "github.com/mail-cci/antispam/internal/config"
+
+func TestVerify(t *testing.T) {
+	cfg := &config.Config{}
+	Init(cfg)
+
+	raw := []byte("From: sender@example.com\r\n\r\nbody")
+	_, _ = Verify(raw)
+}


### PR DESCRIPTION
## Summary
- add `internal/dkim` package with `Verify` helper
- use go-msgauth to validate all DKIM signatures
- small test for the new package
- update go.sum for new dependencies

## Testing
- `go test -mod=mod ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853301b6ce88320873a3034dac5bd5a