### PR TITLE
Add scoring decision helper

### DIFF
--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -1,0 +1,29 @@
+package scoring
+
+import "github.com/mail-cci/antispam/internal/config"
+
+var (
+	RejectThreshold     float64 = 10.0
+	QuarantineThreshold float64 = 5.0
+)
+
+// Init sets the scoring thresholds from the provided configuration.
+func Init(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	RejectThreshold = cfg.Scoring.RejectThreshold
+	QuarantineThreshold = cfg.Scoring.QuarantineThreshold
+}
+
+// Decide returns "reject", "quarantine" or "accept" based on the score
+// compared against the configured thresholds.
+func Decide(score float64) string {
+	if score >= RejectThreshold {
+		return "reject"
+	}
+	if score >= QuarantineThreshold {
+		return "quarantine"
+	}
+	return "accept"
+}

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -1,0 +1,30 @@
+package scoring
+
+import (
+	"testing"
+
+	"github.com/mail-cci/antispam/internal/config"
+)
+
+func TestDecide(t *testing.T) {
+	cfg := &config.Config{Scoring: config.ScoringConfig{RejectThreshold: 10, QuarantineThreshold: 5}}
+	Init(cfg)
+
+	tests := []struct {
+		score    float64
+		expected string
+	}{
+		{11, "reject"},
+		{10, "reject"},
+		{7, "quarantine"},
+		{5, "quarantine"},
+		{4.9, "accept"},
+		{0, "accept"},
+	}
+
+	for _, tt := range tests {
+		if got := Decide(tt.score); got != tt.expected {
+			t.Errorf("Decide(%v) = %q, want %q", tt.score, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add scoring package with thresholds configurable via config
- implement Decide helper to return decision strings
- provide unit tests for decision logic

## Testing
- `go test ./...` *(fails: updates to go.mod needed; go mod tidy)*

------
https://chatgpt.com/codex/tasks/task_e_6853329e2aac8320b8610d98d16af152