### PR TITLE
Implement SPF/DKIM scoring

### DIFF
--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -1,6 +1,7 @@
 package milt
 
 import (
+	"net"
 	"net/textproto"
 	"strings"
 	"testing"
@@ -13,6 +14,19 @@ func TestEmailParsing(t *testing.T) {
 	logger := zap.NewNop()
 	e := MailProcessor(logger)
 	defer e.Close()
+
+	if _, err := e.Connect("localhost", "tcp4", 25, net.ParseIP("127.0.0.1"), nil); err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+	if _, err := e.Helo("mail.local", nil); err != nil {
+		t.Fatalf("Helo returned error: %v", err)
+	}
+	if _, err := e.MailFrom("sender@example.com", nil); err != nil {
+		t.Fatalf("MailFrom returned error: %v", err)
+	}
+	if _, err := e.RcptTo("rcpt@example.com", nil); err != nil {
+		t.Fatalf("RcptTo returned error: %v", err)
+	}
 
 	hdr := textproto.MIMEHeader{}
 	hdr.Add("From", "a@b")
@@ -54,6 +68,19 @@ func TestEmailParsing(t *testing.T) {
 	}
 	if e.attachments[0].Filename != "file.txt" {
 		t.Errorf("unexpected attachment name: %s", e.attachments[0].Filename)
+	}
+
+	if e.clientIP.String() != "127.0.0.1" {
+		t.Errorf("unexpected client IP: %s", e.clientIP.String())
+	}
+	if e.heloHost != "mail.local" {
+		t.Errorf("unexpected helo host: %s", e.heloHost)
+	}
+	if len(e.recipients) != 1 || e.recipients[0] != "rcpt@example.com" {
+		t.Errorf("unexpected recipients: %v", e.recipients)
+	}
+	if e.rawEmail.Len() == 0 {
+		t.Errorf("rawEmail should not be empty")
 	}
 }
 


### PR DESCRIPTION
## Summary
- expand `Email` struct with IP, HELO, recipient list and raw email buffer
- build the raw email, run SPF and DKIM verification, add scoring headers
- log processing details and use score to decide the action
- make SPF verifier tolerant of nil configuration
- extend tests for new fields

## Testing
- `go test -mod=mod ./...`

------
https://chatgpt.com/codex/tasks/task_e_685333fa2acc8320a54e81d0f580c797