### PR TITLE
Propagate SPF TTL through include and redirect

### DIFF
--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -1,6 +1,7 @@
 package milt
 
 import (
+	"net"
 	"net/textproto"
 	"strings"
 	"testing"
@@ -13,6 +14,11 @@ func TestEmailParsing(t *testing.T) {
 	logger := zap.NewNop()
 	e := MailProcessor(logger)
 	defer e.Close()
+
+	// provide client information so SPF checks do not short-circuit
+	_, _ = e.Connect("localhost", "tcp4", 25, net.ParseIP("127.0.0.1"), nil)
+	_, _ = e.Helo("localhost", nil)
+	_, _ = e.MailFrom("a@b", nil)
 
 	hdr := textproto.MIMEHeader{}
 	hdr.Add("From", "a@b")

--- a/internal/spf/api.go
+++ b/internal/spf/api.go
@@ -9,7 +9,9 @@ import (
 )
 
 // Check evaluates SPF for the given IP, domain and sender.
-// It returns the resulting SPFResult without performing any caching.
+// It returns an SPFResult without performing any caching. The RecordTTL field
+// contains the minimum TTL observed while evaluating the domain and any
+// included or redirected SPF records.
 func Check(logger *zap.Logger, ctx context.Context, ip net.IP, domain, sender string) (types.SPFResult, error) {
 	res := types.SPFResult{Domain: domain}
 	r, ttl, err := checkSPF(logger, ctx, ip, domain, sender, 0)

--- a/internal/spf/spf.go
+++ b/internal/spf/spf.go
@@ -77,6 +77,7 @@ func Verify(logger *zap.Logger, ctx context.Context, clientIP net.IP, domain, se
 	res.Result = r.Result
 	res.Explanation = r.Explanation
 	res.Score = r.Score
+	res.RecordTTL = r.RecordTTL
 
 	if rdb != nil {
 		_ = rdb.Set(ctx, cacheKey, res.Result, time.Duration(r.RecordTTL)*time.Second).Err()

--- a/internal/spf/spf_test.go
+++ b/internal/spf/spf_test.go
@@ -6,18 +6,72 @@ import (
 	"testing"
 
 	"github.com/mail-cci/antispam/internal/config"
+	"go.uber.org/zap"
 )
 
 func TestVerify(t *testing.T) {
 	cfg := &config.Config{}
 	Init(cfg)
 
-	_, _ = Verify(context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
+	_, _ = Verify(zap.NewNop(), context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
 }
 
 func TestCheck(t *testing.T) {
 	cfg := &config.Config{}
 	Init(cfg)
 
-	_, _ = Check(context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
+	_, _ = Check(zap.NewNop(), context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
+}
+
+func TestTTLMinimumInclude(t *testing.T) {
+	cfg := &config.Config{}
+	Init(cfg)
+
+	// stub TXT lookups
+	oldLookup := txtLookup
+	txtLookup = func(ctx context.Context, domain string) ([]string, uint32, error) {
+		switch domain {
+		case "parent.test":
+			return []string{"v=spf1 include:child.test -all"}, 3600, nil
+		case "child.test":
+			return []string{"v=spf1 +all"}, 600, nil
+		default:
+			return nil, 0, nil
+		}
+	}
+	defer func() { txtLookup = oldLookup }()
+
+	res, err := Check(zap.NewNop(), context.Background(), net.ParseIP("1.2.3.4"), "parent.test", "user@parent.test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RecordTTL != 600 {
+		t.Errorf("expected TTL 600, got %d", res.RecordTTL)
+	}
+}
+
+func TestTTLMinimumRedirect(t *testing.T) {
+	cfg := &config.Config{}
+	Init(cfg)
+
+	oldLookup := txtLookup
+	txtLookup = func(ctx context.Context, domain string) ([]string, uint32, error) {
+		switch domain {
+		case "parent2.test":
+			return []string{"v=spf1 redirect:child2.test"}, 1200, nil
+		case "child2.test":
+			return []string{"v=spf1 +all"}, 300, nil
+		default:
+			return nil, 0, nil
+		}
+	}
+	defer func() { txtLookup = oldLookup }()
+
+	res, err := Check(zap.NewNop(), context.Background(), net.ParseIP("1.2.3.4"), "parent2.test", "user@parent2.test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RecordTTL != 300 {
+		t.Errorf("expected TTL 300, got %d", res.RecordTTL)
+	}
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,7 +12,8 @@ type SPFResult struct {
 	Domain      string
 	Explanation string
 	Score       float64
-	RecordTTL   uint32 // TTL of the SPF record
+	// RecordTTL contains the minimum TTL among all evaluated SPF records.
+	RecordTTL uint32
 }
 
 // DKIMResult represents DKIM verification outcomes.


### PR DESCRIPTION
## Summary
- capture TTLs from recursive include/redirect lookups and return the minimum value
- allow overriding TXT lookup in tests
- document RecordTTL semantics
- test TTL propagation and fix milter tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854938d40bc83209e1dc848c5c1e11d