### PR TITLE
Add Received-SPF header and tests

### DIFF
--- a/internal/milter/milter.go
+++ b/internal/milter/milter.go
@@ -258,6 +258,11 @@ func (e *Email) Body(m *milter.Modifier) (milter.Response, error) {
 			if err != nil {
 				return nil, err
 			}
+			headerValue := fmt.Sprintf("%s (domain of %s designates %s as permitted sender) client-ip=%s; envelope-from=%s", spfRes.Result, spfRes.Domain, e.clientIP.String(), e.clientIP.String(), e.from)
+			err = m.AddHeader("Received-SPF", headerValue)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			err := m.AddHeader("X-SPF-Result", "")
 			if err != nil {

--- a/internal/milter/milter_receivedspf_test.go
+++ b/internal/milter/milter_receivedspf_test.go
@@ -1,0 +1,97 @@
+package milt
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/textproto"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-milter"
+	"github.com/mail-cci/antispam/internal/config"
+	"github.com/mail-cci/antispam/internal/spf"
+	"go.uber.org/zap"
+)
+
+// helper to set private writePacket field using reflection
+// and record headers added via AddHeader
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+type headerRecorder struct {
+	m       *milter.Modifier
+	headers textproto.MIMEHeader
+}
+
+func newHeaderRecorder() *headerRecorder {
+	hr := &headerRecorder{
+		m:       &milter.Modifier{},
+		headers: make(textproto.MIMEHeader),
+	}
+	hr.m.Headers = hr.headers
+	hr.m.Macros = make(map[string]string)
+	fn := func(msg *milter.Message) error {
+		if msg.Code == byte(milter.ActAddHeader) {
+			parts := bytes.SplitN(msg.Data, []byte{0}, 3)
+			if len(parts) >= 2 {
+				name := string(parts[0])
+				value := string(parts[1])
+				hr.headers.Add(name, value)
+			}
+		}
+		return nil
+	}
+	v := reflect.ValueOf(hr.m).Elem().FieldByName("writePacket")
+	reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().Set(reflect.ValueOf(fn))
+	return hr
+}
+
+func TestReceivedSPFHeaderAdded(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := &config.Config{
+		Auth: config.AuthConfig{SPF: config.SPFConfig{Timeout: time.Second}},
+	}
+	oldCfg := spfCfg
+	spf.Init(cfg)
+	// stub TXT lookups to return pass record
+	setTxtLookup(func(ctx context.Context, domain string) ([]string, uint32, error) {
+		return []string{"v=spf1 +all"}, 600, nil
+	})
+	defer func() {
+		setTxtLookup(nil)
+		spfCfg = oldCfg
+	}()
+
+	e := MailProcessor(logger)
+	defer e.Close()
+
+	_, _ = e.Connect("localhost", "tcp4", 25, net.ParseIP("127.0.0.1"), nil)
+	_, _ = e.Helo("localhost", nil)
+	_, _ = e.MailFrom("user@test.local", nil)
+
+	hdr := textproto.MIMEHeader{}
+	hdr.Add("From", "user@test.local")
+	hdr.Add("To", "dest@example.com")
+	hdr.Add("Subject", "Test")
+
+	if _, err := e.Headers(hdr, nil); err != nil {
+		t.Fatalf("Headers returned error: %v", err)
+	}
+
+	if _, err := e.BodyChunk([]byte("body"), nil); err != nil {
+		t.Fatalf("BodyChunk error: %v", err)
+	}
+
+	rec := newHeaderRecorder()
+	if resp, err := e.Body(rec.m); err != nil || resp != milter.RespAccept {
+		t.Fatalf("Body returned resp=%v err=%v", resp, err)
+	}
+
+	if rec.headers.Get("Received-SPF") == "" {
+		t.Error("Received-SPF header missing")
+	}
+}

--- a/internal/milter/unsafe_test.go
+++ b/internal/milter/unsafe_test.go
@@ -1,0 +1,17 @@
+package milt
+
+import (
+	"context"
+	"github.com/mail-cci/antispam/internal/config"
+	_ "unsafe"
+)
+
+//go:linkname spfTxtLookup github.com/mail-cci/antispam/internal/spf.txtLookup
+var spfTxtLookup func(ctx context.Context, domain string) ([]string, uint32, error)
+
+//go:linkname spfCfg github.com/mail-cci/antispam/internal/spf.cfg
+var spfCfg *config.Config
+
+func setTxtLookup(fn func(ctx context.Context, domain string) ([]string, uint32, error)) {
+	spfTxtLookup = fn
+}


### PR DESCRIPTION
## Summary
- set `Received-SPF` header after SPF verification
- test that header is added when SPF verification passes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855810143288320ad9bee2a8083a763