### PR TITLE
Add SPF metrics instrumentation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,6 +36,27 @@ var (
 		Name: "domains_not_found_total",
 		Help: "Total number of domains not found",
 	})
+
+	SPFChecksTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "spf_checks_total",
+		Help: "Total number of SPF verifications",
+	})
+
+	SPFCheckPass = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "spf_check_pass_total",
+		Help: "Number of SPF verifications that passed",
+	})
+
+	SPFCheckFail = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "spf_check_fail_total",
+		Help: "Number of SPF verifications that failed",
+	})
+
+	SPFCheckDurationSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "spf_check_duration_seconds",
+		Help:    "Duration of SPF verification in seconds",
+		Buckets: prometheus.DefBuckets,
+	})
 )
 
 func Init() {


### PR DESCRIPTION
## Summary
- track SPF check counts and durations in metrics
- instrument SPF Verify with new metrics
- extend SPF tests to validate metrics

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855838f185c8320acbe1486e67c1186