### PR TITLE
Modular logging updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ start the application:
 The program will start the milter and HTTP servers using the ports defined
 in the configuration file.
 
+## Logging
+
+Logs are written under the directory specified by `log.path`. Each module
+creates its own file:
+
+* `main.log` - application startup and shutdown messages
+* `spf.log` - SPF validation logs
+* `dkim.log` - DKIM verification logs
+* `milter.log` - messages from the milter server
+* `api.log` - HTTP API requests
+
 ## Testing
 
 Unit tests can be executed with:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,8 +9,14 @@ import (
 	"go.uber.org/zap"
 )
 
+var logger *zap.Logger
+
+func InitLogger(l *zap.Logger) {
+	logger = l
+}
+
 // NewServer creates and configures a new Gin server instance.
-func NewServer(cfg *config.Config, logger *zap.Logger) *gin.Engine {
+func NewServer(cfg *config.Config) *gin.Engine {
 	// Set Gin mode based on configuration
 	if cfg.Env == "production" {
 		gin.SetMode(gin.ReleaseMode)

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -1,11 +1,14 @@
 package dkim
 
-import "testing"
-import "github.com/mail-cci/antispam/internal/config"
+import (
+	"github.com/mail-cci/antispam/internal/config"
+	"go.uber.org/zap"
+	"testing"
+)
 
 func TestVerify(t *testing.T) {
 	cfg := &config.Config{}
-	Init(cfg)
+	Init(cfg, zap.NewNop())
 
 	raw := []byte("From: sender@example.com\r\n\r\nbody")
 	_, _ = Verify(raw)

--- a/internal/milter/milter_receivedspf_test.go
+++ b/internal/milter/milter_receivedspf_test.go
@@ -56,7 +56,7 @@ func TestReceivedSPFHeaderAdded(t *testing.T) {
 		Auth: config.AuthConfig{SPF: config.SPFConfig{Timeout: time.Second}},
 	}
 	oldCfg := spfCfg
-	spf.Init(cfg)
+	spf.Init(cfg, zap.NewNop())
 	// stub TXT lookups to return pass record
 	setTxtLookup(func(ctx context.Context, domain string) ([]string, uint32, error) {
 		return []string{"v=spf1 +all"}, 600, nil
@@ -66,7 +66,8 @@ func TestReceivedSPFHeaderAdded(t *testing.T) {
 		spfCfg = oldCfg
 	}()
 
-	e := MailProcessor(logger)
+	Init(logger)
+	e := MailProcessor()
 	defer e.Close()
 
 	_, _ = e.Connect("localhost", "tcp4", 25, net.ParseIP("127.0.0.1"), nil)

--- a/internal/milter/milter_test.go
+++ b/internal/milter/milter_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestEmailParsing(t *testing.T) {
 	logger := zap.NewNop()
-	e := MailProcessor(logger)
+	Init(logger)
+	e := MailProcessor()
 	defer e.Close()
 
 	// provide client information so SPF checks do not short-circuit
@@ -65,7 +66,8 @@ func TestEmailParsing(t *testing.T) {
 
 func TestBodyChunkShort(t *testing.T) {
 	logger := zap.NewNop()
-	e := MailProcessor(logger)
+	Init(logger)
+	e := MailProcessor()
 	defer e.Close()
 
 	defer func() {

--- a/internal/spf/api.go
+++ b/internal/spf/api.go
@@ -2,7 +2,6 @@ package spf
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"net"
 
 	"github.com/mail-cci/antispam/internal/types"
@@ -12,9 +11,9 @@ import (
 // It returns an SPFResult without performing any caching. The RecordTTL field
 // contains the minimum TTL observed while evaluating the domain and any
 // included or redirected SPF records.
-func Check(logger *zap.Logger, ctx context.Context, ip net.IP, domain, sender string) (types.SPFResult, error) {
+func Check(ctx context.Context, ip net.IP, domain, sender string) (types.SPFResult, error) {
 	res := types.SPFResult{Domain: domain}
-	r, ttl, err := checkSPF(logger, ctx, ip, domain, sender, 0)
+	r, ttl, err := checkSPF(ctx, ip, domain, sender, 0)
 	if err != nil {
 		return res, err
 	}

--- a/internal/spf/check.go
+++ b/internal/spf/check.go
@@ -124,7 +124,7 @@ func parseMechanism(tok string) (q byte, name, val string) {
 	return
 }
 
-func checkSPF(logger *zap.Logger, ctx context.Context, ip net.IP, domain, sender string, depth int) (string, uint32, error) {
+func checkSPF(ctx context.Context, ip net.IP, domain, sender string, depth int) (string, uint32, error) {
 
 	if depth > maxRecursiveDepth {
 		logger.Error("límite de recursión SPF alcanzado",
@@ -258,7 +258,7 @@ func checkSPF(logger *zap.Logger, ctx context.Context, ip net.IP, domain, sender
 
 		case "include":
 			inc := val
-			r, childTTL, err := checkSPF(logger, ctx, ip, inc, sender, depth+1)
+			r, childTTL, err := checkSPF(ctx, ip, inc, sender, depth+1)
 			if childTTL > 0 && (ttl == 0 || childTTL < ttl) {
 				ttl = childTTL
 			}
@@ -268,7 +268,7 @@ func checkSPF(logger *zap.Logger, ctx context.Context, ip net.IP, domain, sender
 
 		case "redirect":
 			red := val
-			result, childTTL, err := checkSPF(logger, ctx, ip, red, sender, depth+1)
+			result, childTTL, err := checkSPF(ctx, ip, red, sender, depth+1)
 			if childTTL > 0 && (ttl == 0 || childTTL < ttl) {
 				ttl = childTTL
 			}

--- a/internal/spf/spf_test.go
+++ b/internal/spf/spf_test.go
@@ -13,21 +13,21 @@ import (
 
 func TestVerify(t *testing.T) {
 	cfg := &config.Config{}
-	Init(cfg)
+	Init(cfg, zap.NewNop())
 
-	_, _ = Verify(zap.NewNop(), context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
+	_, _ = Verify(context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
 }
 
 func TestCheck(t *testing.T) {
 	cfg := &config.Config{}
-	Init(cfg)
+	Init(cfg, zap.NewNop())
 
-	_, _ = Check(zap.NewNop(), context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
+	_, _ = Check(context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
 }
 
 func TestTTLMinimumInclude(t *testing.T) {
 	cfg := &config.Config{}
-	Init(cfg)
+	Init(cfg, zap.NewNop())
 
 	// stub TXT lookups
 	oldLookup := txtLookup
@@ -43,7 +43,7 @@ func TestTTLMinimumInclude(t *testing.T) {
 	}
 	defer func() { txtLookup = oldLookup }()
 
-	res, err := Check(zap.NewNop(), context.Background(), net.ParseIP("1.2.3.4"), "parent.test", "user@parent.test")
+	res, err := Check(context.Background(), net.ParseIP("1.2.3.4"), "parent.test", "user@parent.test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestTTLMinimumInclude(t *testing.T) {
 
 func TestTTLMinimumRedirect(t *testing.T) {
 	cfg := &config.Config{}
-	Init(cfg)
+	Init(cfg, zap.NewNop())
 
 	oldLookup := txtLookup
 	txtLookup = func(ctx context.Context, domain string) ([]string, uint32, error) {
@@ -69,7 +69,7 @@ func TestTTLMinimumRedirect(t *testing.T) {
 	}
 	defer func() { txtLookup = oldLookup }()
 
-	res, err := Check(zap.NewNop(), context.Background(), net.ParseIP("1.2.3.4"), "parent2.test", "user@parent2.test")
+	res, err := Check(context.Background(), net.ParseIP("1.2.3.4"), "parent2.test", "user@parent2.test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestTTLMinimumRedirect(t *testing.T) {
 
 func TestVerifyMetrics(t *testing.T) {
 	cfg := &config.Config{}
-	Init(cfg)
+	Init(cfg, zap.NewNop())
 
 	oldLookup := txtLookup
 	txtLookup = func(ctx context.Context, domain string) ([]string, uint32, error) {
@@ -92,7 +92,7 @@ func TestVerifyMetrics(t *testing.T) {
 	startPass := testutil.ToFloat64(metrics.SPFCheckPass)
 	startFail := testutil.ToFloat64(metrics.SPFCheckFail)
 
-	_, err := Verify(zap.NewNop(), context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
+	_, err := Verify(context.Background(), net.ParseIP("127.0.0.1"), "example.com", "user@example.com")
 	if err != nil {
 		t.Fatalf("Verify returned error: %v", err)
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -8,10 +8,9 @@ type SPFLookupResult struct {
 
 // SPFResult holds information about SPF check results.
 type SPFResult struct {
-	Result      string
-	Domain      string
-	Explanation string
-	Score       float64
+	Result string
+	Domain string
+	Score  float64
 	// RecordTTL contains the minimum TTL among all evaluated SPF records.
 	RecordTTL uint32
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -18,17 +18,9 @@ type LogConfig struct {
 	ConsoleOutput bool
 }
 
-var (
-	globalLogger *zap.Logger
-	atomicLevel  zap.AtomicLevel
-)
+var atomicLevel = zap.NewAtomicLevel()
 
 func Init(config LogConfig) (*zap.Logger, error) {
-	if globalLogger != nil {
-		return globalLogger, nil
-	}
-
-	atomicLevel = zap.NewAtomicLevel()
 	if err := atomicLevel.UnmarshalText([]byte(config.Level)); err != nil {
 		return nil, err
 	}
@@ -85,25 +77,15 @@ func Init(config LogConfig) (*zap.Logger, error) {
 
 	combinedCore := zapcore.NewTee(cores...)
 
-	globalLogger = zap.New(combinedCore,
+	l := zap.New(combinedCore,
 		zap.AddCaller(),
 		zap.AddCallerSkip(1),
 		zap.AddStacktrace(zapcore.ErrorLevel),
 	)
 
-	zap.ReplaceGlobals(globalLogger)
-
-	return globalLogger, nil
-}
-
-func GetLogger() *zap.Logger {
-	return globalLogger
+	return l, nil
 }
 
 func SetLevel(level string) error {
 	return atomicLevel.UnmarshalText([]byte(level))
-}
-
-func Sync() error {
-	return globalLogger.Sync()
 }


### PR DESCRIPTION
## Summary
- refactor logger to return new instances
- add per-module logger initialization
- use correlation IDs automatically in milter logs
- wire up loggers for SPF, DKIM, API, and milter modules
- document log file locations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855889b8d7c8320b879150b4d1bed1b