### PR TITLE
Update DKIM verification call for DMARC

### DIFF
--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -1122,8 +1122,8 @@ func calculatePartialCreditScore(result *types.DKIMResult) float64 {
 }
 
 // VerifyForDMARC performs DKIM verification specifically for DMARC alignment checking
-func VerifyForDMARC(rawEmail []byte, fromDomain string) (*types.DKIMResult, error) {
-	result, err := VerifyWithCorrelationID(rawEmail, "")
+func VerifyForDMARC(rawEmail []byte, fromDomain, correlationID string) (*types.DKIMResult, error) {
+       result, err := VerifyWithCorrelationID(rawEmail, correlationID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dkim/dkim_integration_test.go
+++ b/internal/dkim/dkim_integration_test.go
@@ -179,7 +179,7 @@ Subject: DMARC Alignment Test
 
 Testing DMARC alignment scenarios.`)
 
-	result, err := VerifyForDMARC(testEmail, "example.com")
+       result, err := VerifyForDMARC(testEmail, "example.com", "")
 	if err != nil && result == nil {
 		t.Fatalf("DMARC verification failed: %v", err)
 	}

--- a/internal/milter/milter.go
+++ b/internal/milter/milter.go
@@ -285,7 +285,7 @@ func (e *Email) Body(m *milter.Modifier) (milter.Response, error) {
 	go func() {
 		defer wg.Done()
 		
-		res, err := dkim.VerifyWithCorrelationID(e.rawEmail.Bytes(), e.id)
+               res, err := dkim.VerifyForDMARC(e.rawEmail.Bytes(), fromHeaderDomain, e.id)
 		if err != nil {
 			e.logger.Error("Error verifying DKIM", zap.Error(err))
 			return


### PR DESCRIPTION
## Summary
- use `VerifyForDMARC` in milter with correlation ID
- extend `VerifyForDMARC` API to accept correlation ID
- adapt integration tests for new function signature

## Testing
- `go test ./...` *(fails: TestMultipleSignatures, TestSignatureScoring, TestVerifyIntegration)*

------
https://chatgpt.com/codex/tasks/task_e_685ed35c146c8320a9a8a32d6cf9d107