### PR TITLE
Add anomaly for weak DKIM hash usage

### DIFF
--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -1353,10 +1353,14 @@ func analyzeHashAlgorithms(signatures []types.DKIMSignatureResult, info *types.D
 		}
 	}
 
-	// Check for mixed hash algorithms
-	if len(hashAlgorithms) > 1 {
-		info.Anomalies = append(info.Anomalies, types.AnomalyMixedHashAlgorithms)
-	}
+// Check for mixed hash algorithms
+if len(hashAlgorithms) > 1 {
+info.Anomalies = append(info.Anomalies, types.AnomalyMixedHashAlgorithms)
+}
+
+if weakHashCount > 0 {
+info.Anomalies = append(info.Anomalies, types.AnomalyWeakHashAlgorithm)
+}
 }
 
 // analyzeSignatureTiming checks for timing-related anomalies

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -49,6 +49,8 @@ const (
 	AnomalyNone                    DKIMAnomalyFlag = ""
 	AnomalyMultipleValidDomains    DKIMAnomalyFlag = "multiple_valid_domains"
 	AnomalyMixedHashAlgorithms     DKIMAnomalyFlag = "mixed_hash_algorithms"
+	// AnomalyWeakHashAlgorithm is triggered when signatures use weak hash algorithms like SHA-1
+	AnomalyWeakHashAlgorithm       DKIMAnomalyFlag = "weak_hash_algorithm"
 	AnomalyExpiredSignatures       DKIMAnomalyFlag = "expired_signatures"
 	AnomalyFutureSignatures        DKIMAnomalyFlag = "future_signatures"
 	AnomalyTooManySignatures       DKIMAnomalyFlag = "too_many_signatures"


### PR DESCRIPTION
## Summary
- recognize weak hash algorithms as an anomaly
- report it when signatures use SHA‑1 hashes

## Testing
- `go test ./...` *(fails: expected score mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685ed9e7bb5c83208ec5112af9cd1a79